### PR TITLE
Add Cargo.lock to VCS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,41 @@
+[root]
+name = "wtftw"
+version = "0.1.0"
+dependencies = [
+ "wtftw_core 0.2.0 (git+https://github.com/Kintaro/wtftw-core.git)",
+ "wtftw_xlib 0.2.0 (git+https://github.com/Kintaro/wtftw-xlib.git)",
+]
+
+[[package]]
+name = "wtftw_core"
+version = "0.2.0"
+source = "git+https://github.com/Kintaro/wtftw-core.git#8a2757bd7322172452f53c331dd2369743ef7059"
+
+[[package]]
+name = "wtftw_xlib"
+version = "0.2.0"
+source = "git+https://github.com/Kintaro/wtftw-xlib.git#f1bc2d85efda7d95412a128c3f27c898dd47692b"
+dependencies = [
+ "wtftw_core 0.2.0 (git+https://github.com/Kintaro/wtftw-core.git)",
+ "xinerama 0.0.1 (git+https://github.com/Kintaro/rust-xinerama.git)",
+ "xlib 0.1.0 (git+https://github.com/Kintaro/rust-xlib.git?ref=sizehint)",
+]
+
+[[package]]
+name = "xinerama"
+version = "0.0.1"
+source = "git+https://github.com/Kintaro/rust-xinerama.git#660f3a0919480d0801db51dc21c831e0cfef74fb"
+dependencies = [
+ "xlib 0.1.0 (git+https://github.com/Kintaro/rust-xlib.git)",
+]
+
+[[package]]
+name = "xlib"
+version = "0.1.0"
+source = "git+https://github.com/Kintaro/rust-xlib.git#e81fd3f7c903cf3b2245a9aff659603700312208"
+
+[[package]]
+name = "xlib"
+version = "0.1.0"
+source = "git+https://github.com/Kintaro/rust-xlib.git?ref=sizehint#60c2c9923f2476e61cfa94080b1b3a6806a9e9f4"
+


### PR DESCRIPTION
We are a binary, so Cargo.lock should be checked in.

http://doc.crates.io/faq.html#why-do-binaries-have-cargo.lock-in-version-control,-but-not-libraries?
