### PR TITLE
Patch: #33 and #40; No longer assuming Option is Some for unwrap() for find_screen.

### DIFF
--- a/core/src/core.rs
+++ b/core/src/core.rs
@@ -639,13 +639,14 @@ impl<'a> Workspaces<'a> {
             .nth(0)
     }
 
-    pub fn find_screen(&self, window: Window) -> Screen<'a> {
+    pub fn find_screen(&self, window: Window) -> Option<Screen<'a>> {
         if self.current.contains(window) {
-            self.current.clone()
+            Some(self.current.clone())
         } else {
-            self.visible.iter()
-                .filter(|x| x.contains(window))
-                .nth(0).unwrap().clone()
+            match self.visible.iter().filter(|x| x.contains(window)).nth(0) {
+                Some(s) => Some(s.clone()),
+                None => None
+            }
         }
     }
 

--- a/core/src/window_manager.rs
+++ b/core/src/window_manager.rs
@@ -157,15 +157,17 @@ impl<'a> WindowManager<'a> {
 
     pub fn focus(&self, window: Window, window_system: &WindowSystem,
                  config: &GeneralConfig<'a>) -> WindowManager<'a> {
-        let screen = self.workspaces.find_screen(window);
-
-        if screen.screen_id == self.workspaces.current.screen_id && screen.workspace.peek() != Some(window) {
-            self.windows(window_system, config, |w| w.focus_window(window))
-        } else if window == window_system.get_root() {
-            self.windows(window_system, config, |w| w.view(screen.workspace.id))
-        } else {
-            self.clone()
-        }
+        match self.workspaces.find_screen(window) {
+            Some(screen) => {
+                if screen.screen_id == self.workspaces.current.screen_id && screen.workspace.peek() != Some(window) {
+                    return self.windows(window_system, config, |w| w.focus_window(window))
+                } else if window == window_system.get_root() {
+                    return self.windows(window_system, config, |w| w.view(screen.workspace.id))
+                }
+            },
+            None => ()
+        };
+        self.clone()
     }
 
     pub fn focus_down(&self) -> WindowManager<'a> {


### PR DESCRIPTION
Safely use Option for find_screen, no longer assuming Option is Some. It is very risky to use Option::unwrap(). Patching: #33 and #40.
