### PR TITLE
Fix CLike impl

### DIFF
--- a/core/src/layout.rs
+++ b/core/src/layout.rs
@@ -379,11 +379,11 @@ impl Direction {
 }
 
 impl CLike for Direction {
-    fn to_uint(&self) -> usize {
+    fn to_usize(&self) -> usize {
         *self as usize
     }
 
-    fn from_uint(v: usize) -> Direction {
+    fn from_usize(v: usize) -> Direction {
         match v {
             0 => Direction::Up,
             1 => Direction::Down,


### PR DESCRIPTION
Methods are now to_usize and from_usize (as of a few days ago).