### PR TITLE
Replace `into_string` with `to_string`

### DIFF
--- a/src/wtftw.rs
+++ b/src/wtftw.rs
@@ -24,7 +24,7 @@ pub fn parse_window_ids(ids: &str) -> Vec<(Window, u32)> {
 
 fn main() {
     // Parse command line arguments
-    let args : Vec<String> = env::args().map(|x| x.into_string().unwrap()).collect();
+    let args : Vec<String> = env::args().map(|x| x.to_string()).collect();
 
     let mut options = Options::new();
     options.optopt("r", "resume", "list of window IDs to capture in resume", "WINDOW");


### PR DESCRIPTION
* `into_string` is no longer a method on strings but `to_string` works
  and doesn't need to be unwrapped

I tried building wtftw last night and had to add this change for it to compile with the rust nightly bin on the AUR.