### PR TITLE
Fixed build issue and warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wtftw_core 0.2.0",
  "wtftw_xlib 0.2.0",
 ]
@@ -30,7 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -39,7 +39,7 @@ version = "0.2.0"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/xlib/Cargo.lock
+++ b/xlib/Cargo.lock
@@ -2,6 +2,7 @@
 name = "wtftw_xlib"
 version = "0.2.0"
 dependencies = [
+ "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wtftw_core 0.2.0",
  "xinerama 0.0.1 (git+https://github.com/Kintaro/rust-xinerama.git)",
  "xlib 0.1.0 (git+https://github.com/Kintaro/rust-xlib.git?branch=wtftw)",
@@ -14,12 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.12"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -27,8 +28,8 @@ name = "wtftw_core"
 version = "0.2.0"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/xlib/Cargo.toml
+++ b/xlib/Cargo.toml
@@ -4,6 +4,9 @@ name = "wtftw_xlib"
 version = "0.2.0"
 authors = ["Simon Wollwage"]
 
+[dependencies]
+log = "*"
+
 [dependencies.xlib]
 git = "https://github.com/Kintaro/rust-xlib.git"
 branch = "wtftw"

--- a/xlib/src/xlib_window_system.rs
+++ b/xlib/src/xlib_window_system.rs
@@ -1,5 +1,7 @@
 #![feature(plugin)]
 #![feature(libc)]
+#![feature(core)]
+#![feature(collections)]
 #[macro_use]
 
 extern crate log;


### PR DESCRIPTION
Fixed build issue caused by rustc-serialize.
Fixed warnings from xlib by depending on the log crate and adding the appropriate `#[feature(...)]` attributes.