### PR TITLE
Stable Rust

### DIFF
--- a/config/config.rs
+++ b/config/config.rs
@@ -1,15 +1,10 @@
-#![feature(unboxed_closures)]
-#![feature(plugin)]
-#![feature(box_syntax)]
-#![feature(std_misc, collections, path_ext)]
 #[macro_use]
 #[macro_use]
 extern crate wtftw;
 extern crate wtftw_contrib;
 
-use std::fs::PathExt;
 use std::io::Write;
-use std::path::Path;
+use std::fs::metadata;
 use std::env;
 use std::ops::Deref;
 //use std::ffi::AsOsStr;
@@ -35,7 +30,7 @@ pub extern fn configure(_: &mut WindowManager, w: &WindowSystem, config: &mut Co
     config.general.layout = LayoutCollection::new(vec!(
             GapLayout::new(0, AvoidStrutsLayout::new(vec!(Direction::Up, Direction::Down), BinarySpacePartition::new())),
             GapLayout::new(0, AvoidStrutsLayout::new(vec!(Direction::Up, Direction::Down), MirrorLayout::new(BinarySpacePartition::new()))),
-            NoBordersLayout::new(box FullLayout)));
+            NoBordersLayout::new(Box::new(FullLayout))));
 
     config.general.tags = (vec!("一: ターミナル", "二: ウェブ", "三: コード",
                                 "四: メディア", "五: スチーム", "六: ラテック",
@@ -121,11 +116,11 @@ pub extern fn configure(_: &mut WindowManager, w: &WindowSystem, config: &mut Co
     let home = home_dir.as_os_str().to_str().unwrap();
     let xmobar_config = format!("{}/.xmonad/xmobar1.hs", home);
 
-    if Path::new(&xmobar_config.clone()).is_file() {
+    if metadata(&xmobar_config).map(|s| s.is_file()).unwrap_or(false) {
         let mut xmobar = spawn_pipe(config, "/home/rootnode/.cabal/bin/xmobar",
                                     vec!(xmobar_config));
         let tags = config.general.tags.clone();
-        config.set_log_hook(box move |m, w| {
+        config.set_log_hook(Box::new(move |m, w| {
             let p = &mut xmobar;
             let tags = &tags;
             let workspaces = tags.clone().iter()
@@ -157,6 +152,6 @@ pub extern fn configure(_: &mut WindowManager, w: &WindowSystem, config: &mut Co
                 },
                 _ => ()
             }
-        });
+        }));
     };
 }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -15,7 +15,6 @@ use std::mem;
 use std::error::Error;
 use std::fs::File;
 use std::io::Write;
-use std::fs::PathExt;
 use std::fs::{ read_dir, create_dir_all };
 use std::process::Command;
 use std::process::Child;
@@ -25,6 +24,7 @@ use std::sync::RwLock;
 use std::thread::spawn;
 use std::path::PathBuf;
 use std::path::Path;
+use std::fs::metadata;
 
 pub struct GeneralConfig {
     /// Whether focus follows mouse movements or
@@ -177,14 +177,14 @@ impl Config {
     pub fn compile_and_call(&mut self, m: &mut WindowManager, w: &WindowSystem) {
         let toml = format!("{}/Cargo.toml", self.internal.wtftw_dir.clone());
 
-        if !Path::new(&self.internal.wtftw_dir.clone()).exists() {
+        if !path_exists(&self.internal.wtftw_dir.clone()) {
             match create_dir_all(Path::new(&self.internal.wtftw_dir.clone())) {
                 Ok(()) => (),
                 Err(e) => panic!(format!("mkdir: {} failed with error {}", self.internal.wtftw_dir.clone(), e))
             }
         }
 
-        if !Path::new(&toml.clone()).exists() {
+        if path_exists(&toml.clone()) {
             let file = File::create(Path::new(&toml).as_os_str());
             file.unwrap().write("[project]\n\
                                      name = \"config\"\n\
@@ -200,7 +200,7 @@ impl Config {
         }
 
         let config_source = format!("{}/src/config.rs", self.internal.wtftw_dir.clone());
-        if Path::new(&config_source).exists() && self.compile() {
+        if path_exists(&config_source) && self.compile() {
             self.call(m, w)
         } else {
             self.default_configuration(w);
@@ -270,4 +270,8 @@ impl Config {
             }
         }
     }
+}
+
+fn path_exists(path: &String) -> bool {
+    metadata(path).is_ok()
 }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -184,7 +184,7 @@ impl Config {
             }
         }
 
-        if path_exists(&toml.clone()) {
+        if !path_exists(&toml.clone()) {
             let file = File::create(Path::new(&toml).as_os_str());
             file.unwrap().write("[project]\n\
                                      name = \"config\"\n\

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -12,21 +12,21 @@ use window_system::*;
 #[macro_export]
 macro_rules! add_key_handler_str(
     ($config: expr, $w:expr, $key:expr, $modkey:expr, $inp:expr) => (
-        $config.add_key_handler($w.get_keycode_from_string($key), $modkey, box $inp);
+        $config.add_key_handler($w.get_keycode_from_string($key), $modkey, Box::new($inp));
     )
 );
 
 #[macro_export]
 macro_rules! add_key_handler_code(
     ($config: expr, $key:expr, $modkey:expr, $inp:expr) => (
-        $config.add_key_handler($key, $modkey, box $inp);
+        $config.add_key_handler($key, $modkey, Box::new($inp));
     )
 );
 
 #[macro_export]
 macro_rules! add_mouse_handler(
     ($config: expr, $button:expr, $modkey:expr, $inp:expr) => (
-        $config.add_mouse_handler($button, $modkey, box $inp);
+        $config.add_mouse_handler($button, $modkey, Box::new($inp));
     )
 );
 

--- a/core/src/wtftw.rs
+++ b/core/src/wtftw.rs
@@ -1,4 +1,3 @@
-#![feature(unboxed_closures)]
 #[deny(warnings)]
 #[macro_use]
 #[link]

--- a/core/src/wtftw.rs
+++ b/core/src/wtftw.rs
@@ -1,5 +1,4 @@
 #![feature(unboxed_closures)]
-#![feature(path_ext)]
 #[deny(warnings)]
 #[macro_use]
 #[link]


### PR DESCRIPTION
I ported the main parts of wtftw (not the sample config) to stable Rust. This allows wtftw to be build on Rust 1.1.0. The changes are rather minor:

* don't use unboxed closures (this could be hidden behind a `-nightly` feature flag if gains are very high)
* use the internal implementation of PathExt#exists() instead of the thing directly, as it is currently unstable. This includes a little refactoring saving some code.