### PR TITLE
Update bitflags and make KeyModifiers public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "wtftw"
 version = "0.4.4"
 dependencies = [
- "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dylib 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.1.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -102,7 +102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "wtftw_core"
 version = "0.3.1"
 dependencies = [
- "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dylib 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.1"
 authors = ["Simon Wollwage"]
 
 [dependencies]
-bitflags = "0.1"
+bitflags = "0.5.0"
 rustc-serialize = "*"
 log = "*"
 num = "*"

--- a/core/src/window_system.rs
+++ b/core/src/window_system.rs
@@ -79,7 +79,7 @@ impl MouseCommand {
 }
 
 bitflags! {
-    flags KeyModifiers : u32 {
+    pub flags KeyModifiers : u32 {
         const NONEMASK    = (0 << 0),
         const SHIFTMASK   = (1 << 0),
         const LOCKMASK    = (1 << 1),
@@ -195,5 +195,3 @@ pub trait WindowSystem {
     fn update_server_state(&self, manager: &WindowManager);
     fn process_message(&self, window_manager: &WindowManager, config: &GeneralConfig, window: Window, atom: c_ulong) -> WindowManager;
 }
- 
-


### PR DESCRIPTION
This is intended to make KeyModifiers public to be able to be used by config.rs.