### PR TITLE
CHORE: Apply manage hook on resume

### DIFF
--- a/src/wtftw.rs
+++ b/src/wtftw.rs
@@ -79,7 +79,9 @@ fn main() {
     for (window, workspace) in window_ids {
         debug!("re-inserting window {}", window);
         window_manager = window_manager.view(window_system.deref(), workspace, &config.general)
-            .manage(window_system.deref(), window, &config.general);
+            .manage(window_system.deref(), window, &config.general).windows(window_system.deref(), &config.general,
+                                                        &|x| (config.internal.manage_hook)(x.clone(),
+                                                        window_system.clone(), window));
     }
 
     window_manager = (*config.internal.startup_hook)(window_manager, window_system.clone(), &config);


### PR DESCRIPTION
Apply manage hook on resume.

This will allow users to keep their windows in the state they want, besides just which workspace they were on at the moment of resume.