### PR TITLE
Set bitflags to 0.5.0 to avoid issues with different versions of macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.4.4"
 authors = ["Simon Wollwage"]
 
 [dependencies]
-bitflags = "*"
+bitflags = "0.5"
 rustc-serialize = "*"
 getopts = "*"
 log = "*"


### PR DESCRIPTION
Build was broken on master because bitflags was updated to 1.0.0 with breaking changes. I'm not sure if this counts as a bug in the Rust compiler, but it seemed like the 1.0.0 version in the root crate overrode the 0.5.0 in wtftw_core, letting wtftw_core build by itself but breaking when compiling wtftw