### PR TITLE
Fix deprecated #[link] directive + remove warnings

### DIFF
--- a/core/src/core/screen.rs
+++ b/core/src/core/screen.rs
@@ -64,7 +64,7 @@ impl Screen {
         Screen::new(self.workspace.map_or(default, f), self.screen_id, self.screen_detail)
     }
 
-    pub fn send_layout_message(&self, message: LayoutMessage, window_system: &WindowSystem,
+    pub fn send_layout_message(&self, message: LayoutMessage, window_system: &dyn WindowSystem,
                                    config: &GeneralConfig) -> Screen {
         Screen::new(self.workspace.send_layout_message(message, window_system, config), self.screen_id, self.screen_detail)
     }

--- a/core/src/core/workspace.rs
+++ b/core/src/core/workspace.rs
@@ -8,7 +8,7 @@ use core::stack::Stack;
 pub struct Workspace {
     pub id:     u32,
     pub tag:    String,
-    pub layout: Box<Layout>,
+    pub layout: Box<dyn Layout>,
     pub stack:  Option<Stack<Window>>
 }
 
@@ -25,7 +25,7 @@ impl Clone for Workspace {
 
 impl Workspace {
     /// Create a new workspace
-    pub fn new(id: u32, tag: String, layout: Box<Layout>, stack: Option<Stack<Window>>) -> Workspace {
+    pub fn new(id: u32, tag: String, layout: Box<dyn Layout>, stack: Option<Stack<Window>>) -> Workspace {
         Workspace {
             id: id,
             tag: tag,
@@ -77,7 +77,7 @@ impl Workspace {
         Some(self.stack.clone().map_or(default, |x| f(x))))
     }
 
-    pub fn send_layout_message(&self, message: LayoutMessage, window_system: &WindowSystem,
+    pub fn send_layout_message(&self, message: LayoutMessage, window_system: &dyn WindowSystem,
                                    config: &GeneralConfig) -> Workspace {
         let mut layout = self.layout.copy();
         layout.apply_message(message, window_system, &self.stack, config);

--- a/core/src/core/workspaces.rs
+++ b/core/src/core/workspaces.rs
@@ -39,7 +39,7 @@ impl Workspaces {
     /// list will be current.
     ///
     /// Xinerama: Virtual workspaces are assigned to physical screens, starting at 0.
-    pub fn new(layout: Box<Layout>, tags: Vec<String>, screens: Vec<ScreenDetail>) -> Workspaces {
+    pub fn new(layout: Box<dyn Layout>, tags: Vec<String>, screens: Vec<ScreenDetail>) -> Workspaces {
         debug!("creating new workspaces with {} screen(s)", screens.len());
         let workspaces : Vec<Workspace> = tags.iter()
             .enumerate()

--- a/core/src/handlers.rs
+++ b/core/src/handlers.rs
@@ -8,11 +8,11 @@ use window_system::WindowSystem;
 use window_system::Window;
 use config::{ GeneralConfig, Config };
 
-pub type KeyHandler = Box<Fn(WindowManager, Rc<WindowSystem>, &GeneralConfig) -> WindowManager>;
-pub type MouseHandler = Box<Fn(WindowManager, Rc<WindowSystem>, &GeneralConfig, Window) -> WindowManager>;
-pub type ManageHook = Box<Fn(Workspaces, Rc<WindowSystem>, Window) -> Workspaces>;
-pub type StartupHook = Box<Fn(WindowManager, Rc<WindowSystem>, &Config) -> WindowManager>;
-pub type LogHook = Box<FnMut(WindowManager, Rc<WindowSystem>)>;
+pub type KeyHandler = Box<Fn(WindowManager, Rc<dyn WindowSystem>, &GeneralConfig) -> WindowManager>;
+pub type MouseHandler = Box<Fn(WindowManager, Rc<dyn WindowSystem>, &GeneralConfig, Window) -> WindowManager>;
+pub type ManageHook = Box<Fn(Workspaces, Rc<dyn WindowSystem>, Window) -> Workspaces>;
+pub type StartupHook = Box<Fn(WindowManager, Rc<dyn WindowSystem>, &Config) -> WindowManager>;
+pub type LogHook = Box<FnMut(WindowManager, Rc<dyn WindowSystem>)>;
 
 extern {
     pub fn waitpid(fd: libc::pid_t, status: *mut libc::c_int, options: libc::c_int) -> libc::pid_t;
@@ -35,7 +35,7 @@ pub mod default {
     use std::rc::Rc;
     use std::ops::Deref;
 
-    pub fn start_terminal(window_manager: WindowManager, _: Rc<WindowSystem>,
+    pub fn start_terminal(window_manager: WindowManager, _: Rc<dyn WindowSystem>,
                           config: &GeneralConfig) -> WindowManager {
         let (terminal, args) = config.terminal.clone();
         let arguments : Vec<String> = if args.is_empty() {
@@ -60,7 +60,7 @@ pub mod default {
         window_manager.clone()
     }
 
-    pub fn start_launcher(window_manager: WindowManager, _: Rc<WindowSystem>,
+    pub fn start_launcher(window_manager: WindowManager, _: Rc<dyn WindowSystem>,
                           config: &GeneralConfig) -> WindowManager {
         let launcher = config.launcher.clone();
         spawn(move || {
@@ -74,12 +74,12 @@ pub mod default {
         window_manager.clone()
     }
 
-    pub fn switch_to_workspace(window_manager: WindowManager, window_system: Rc<WindowSystem>,
+    pub fn switch_to_workspace(window_manager: WindowManager, window_system: Rc<dyn WindowSystem>,
                                config: &GeneralConfig, index: usize) -> WindowManager {
         window_manager.view(window_system.deref(), index as u32, config)
     }
 
-    pub fn move_window_to_workspace(window_manager: WindowManager, window_system: Rc<WindowSystem>,
+    pub fn move_window_to_workspace(window_manager: WindowManager, window_system: Rc<dyn WindowSystem>,
                                     config: &GeneralConfig, index: usize) -> WindowManager {
         window_manager.move_window_to_workspace(window_system.deref(), config, index as u32)
     }
@@ -88,7 +88,7 @@ pub mod default {
     /// with the new one in memory.
     /// Pass a list of all windows to it via command line arguments
     /// so it may resume work as usual.
-    pub fn restart<'a>(window_manager: WindowManager, _: Rc<WindowSystem>, c: &GeneralConfig) -> WindowManager {
+    pub fn restart<'a>(window_manager: WindowManager, _: Rc<dyn WindowSystem>, c: &GeneralConfig) -> WindowManager {
         // Get absolute path to binary
         let filename = env::current_dir().unwrap().join(&env::current_exe().unwrap());
         // Collect all managed windows
@@ -119,7 +119,7 @@ pub mod default {
     }
 
     /// Stop the window manager
-    pub fn exit(w: WindowManager, _: Rc<WindowSystem>, _: &GeneralConfig) -> WindowManager {
+    pub fn exit(w: WindowManager, _: Rc<dyn WindowSystem>, _: &GeneralConfig) -> WindowManager {
         WindowManager { running: false, dragging: None, workspaces: w.workspaces, waiting_unmap: w.waiting_unmap.clone() }
     }
 

--- a/core/src/layout.rs
+++ b/core/src/layout.rs
@@ -64,13 +64,13 @@ pub fn split_horizontally_by(ratio: f32, screen: ScreenDetail) -> (Rectangle, Re
 }
 
 pub trait Layout {
-    fn apply_layout(&mut self, window_system: &WindowSystem, screen: Rectangle, config: &GeneralConfig,
+    fn apply_layout(&mut self, window_system: &dyn WindowSystem, screen: Rectangle, config: &GeneralConfig,
                     stack: &Option<Stack<Window>>) -> Vec<(Window, Rectangle)>;
-    fn apply_message(&mut self, _: LayoutMessage, _: &WindowSystem,
+    fn apply_message(&mut self, _: LayoutMessage, _: &dyn WindowSystem,
                          _: &Option<Stack<Window>>, _: &GeneralConfig) -> bool { true }
     fn description(&self) -> String;
-    fn copy(&self) -> Box<Layout> { panic!("") }
-    fn unhook(&self, _: &WindowSystem, _: &Option<Stack<Window>>, _: &GeneralConfig) { }
+    fn copy(&self) -> Box<dyn Layout> { panic!("") }
+    fn unhook(&self, _: &dyn WindowSystem, _: &Option<Stack<Window>>, _: &GeneralConfig) { }
 }
 
 #[derive(Clone, Copy)]
@@ -81,7 +81,7 @@ pub struct TallLayout {
 }
 
 impl TallLayout {
-    pub fn new() -> Box<Layout> {
+    pub fn new() -> Box<dyn Layout> {
         Box::new(TallLayout {
             num_master: 1,
             increment_ratio: 0.03,
@@ -91,7 +91,7 @@ impl TallLayout {
 }
 
 impl Layout for TallLayout {
-    fn apply_layout(&mut self, _: &WindowSystem, screen: Rectangle, _: &GeneralConfig,
+    fn apply_layout(&mut self, _: &dyn WindowSystem, screen: Rectangle, _: &GeneralConfig,
                     stack: &Option<Stack<Window>>) -> Vec<(Window, Rectangle)> {
         match stack {
             &Some(ref s) => {
@@ -105,7 +105,7 @@ impl Layout for TallLayout {
         }
     }
 
-    fn apply_message(&mut self, message: LayoutMessage, _: &WindowSystem,
+    fn apply_message(&mut self, message: LayoutMessage, _: &dyn WindowSystem,
                          _: &Option<Stack<Window>>, _: &GeneralConfig) -> bool {
         match message {
             LayoutMessage::Increase => { self.ratio += 0.05; true }
@@ -122,7 +122,7 @@ impl Layout for TallLayout {
         "Tall".to_owned()
     }
 
-    fn copy(&self) -> Box<Layout> {
+    fn copy(&self) -> Box<dyn Layout> {
         Box::new(self.clone())
     }
 }

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -58,7 +58,7 @@ pub fn spawn_pipe<S: AsRef<OsStr>>(config: &mut Config, program: S, args: Vec<St
     rc
 }
 
-pub fn spawn_on(workspaces: Workspaces, _: &WindowSystem,
+pub fn spawn_on(workspaces: Workspaces, _: &dyn WindowSystem,
                 window: Window, workspace_id: u32) -> Workspaces {
     workspaces.focus_window(window).shift(workspace_id)
 }

--- a/core/src/window_manager.rs
+++ b/core/src/window_manager.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeSet;
 use std::cmp;
 
 pub type ScreenDetail = Rectangle;
-pub type MouseDrag = Box<Fn(u32, u32, WindowManager, &WindowSystem) -> WindowManager>;
+pub type MouseDrag = Box<Fn(u32, u32, WindowManager, &dyn WindowSystem) -> WindowManager>;
 
 #[derive(Clone)]
 pub struct WindowManager {
@@ -28,7 +28,7 @@ pub struct WindowManager {
 
 impl WindowManager {
     /// Create a new window manager for the given window system and configuration
-    pub fn new(window_system: &WindowSystem, config: &GeneralConfig) -> WindowManager {
+    pub fn new(window_system: &dyn WindowSystem, config: &GeneralConfig) -> WindowManager {
         WindowManager {
             running: true,
             dragging: None,
@@ -47,7 +47,7 @@ impl WindowManager {
     /// Switch to the workspace given by index. If index is out of bounds,
     /// just do nothing and return.
     /// Then, reapply the layout to show the changes.
-    pub fn view(&self, window_system: &WindowSystem, index: u32,
+    pub fn view(&self, window_system: &dyn WindowSystem, index: u32,
                 config: &GeneralConfig) -> WindowManager {
         if index < self.workspaces.number_workspaces() {
             debug!("switching to workspace {}", config.tags[index as usize].clone());
@@ -57,7 +57,7 @@ impl WindowManager {
         }
     }
 
-    pub fn move_window_to_workspace(&self, window_system: &WindowSystem,
+    pub fn move_window_to_workspace(&self, window_system: &dyn WindowSystem,
                                     config: &GeneralConfig,
                                     index: u32) -> WindowManager {
         self.windows(window_system, config, &|w| w.shift(index))
@@ -65,7 +65,7 @@ impl WindowManager {
 
     /// Rearrange the workspaces across the given screens.
     /// Needs to be called when the screen arrangement changes.
-    pub fn rescreen(&self, window_system: &WindowSystem) -> WindowManager {
+    pub fn rescreen(&self, window_system: &dyn WindowSystem) -> WindowManager {
         let screens = window_system.get_screen_infos();
         let visible : Vec<Workspace> = (vec!(self.workspaces.current.clone())).iter()
             .chain(self.workspaces.visible.iter())
@@ -94,7 +94,7 @@ impl WindowManager {
         })
     }
 
-    pub fn update_layouts(&self, window_system: &WindowSystem,
+    pub fn update_layouts(&self, window_system: &dyn WindowSystem,
                           config: &GeneralConfig) -> WindowManager {
         let screens : Vec<Screen> = self.workspaces.screens().into_iter().map(|s| {
             let mut ms = s.clone();
@@ -113,7 +113,7 @@ impl WindowManager {
         }
     }
 
-    pub fn unfocus_windows(&self, window_system: &WindowSystem, config: &GeneralConfig) {
+    pub fn unfocus_windows(&self, window_system: &dyn WindowSystem, config: &GeneralConfig) {
         for &win in self.workspaces.visible_windows().iter() {
             window_system.set_window_border_color(win, config.border_color);
         }
@@ -121,7 +121,7 @@ impl WindowManager {
 
     /// Manage a new window that was either created just now or already present
     /// when the WM started.
-    pub fn manage(&self, window_system: &WindowSystem, window: Window,
+    pub fn manage(&self, window_system: &dyn WindowSystem, window: Window,
                   config: &GeneralConfig) -> WindowManager {
         fn adjust(RationalRect(x, y, w, h): RationalRect) -> RationalRect {
             if x + w > 1.0 || y + h > 1.0 || x < 0.0 || y < 0.0 {
@@ -153,7 +153,7 @@ impl WindowManager {
     }
 
     /// Unmanage a window. This happens when a window is closed.
-    pub fn unmanage(&self, window_system: &WindowSystem, window: Window,
+    pub fn unmanage(&self, window_system: &dyn WindowSystem, window: Window,
                     config: &GeneralConfig) -> WindowManager {
         if self.workspaces.contains(window) {
             debug!("unmanaging window {}", window);
@@ -163,7 +163,7 @@ impl WindowManager {
         }
     }
 
-    pub fn focus(&self, window: Window, window_system: &WindowSystem,
+    pub fn focus(&self, window: Window, window_system: &dyn WindowSystem,
                  config: &GeneralConfig) -> WindowManager {
         if let Some(screen) = self.workspaces.find_screen(window) {
             if screen.screen_id == self.workspaces.current.screen_id &&
@@ -193,12 +193,12 @@ impl WindowManager {
         }
     }
 
-    pub fn reveal(&self, window_system: &WindowSystem, window: Window) -> WindowManager {
+    pub fn reveal(&self, window_system: &dyn WindowSystem, window: Window) -> WindowManager {
         window_system.show_window(window);
         self.clone()
     }
 
-    pub fn windows<F>(&self, window_system: &WindowSystem, config: &GeneralConfig,
+    pub fn windows<F>(&self, window_system: &dyn WindowSystem, config: &GeneralConfig,
                    f: &F) -> WindowManager where F : Fn(&Workspaces) -> Workspaces {
         let ws = f(&self.workspaces);
         let old_visible = self.workspaces.visible_windows().into_iter().collect::<BTreeSet<_>>();
@@ -280,19 +280,19 @@ impl WindowManager {
     }
 
     /// Send the given message to the current layout
-    pub fn send_layout_message(&self, message: LayoutMessage, window_system: &WindowSystem,
+    pub fn send_layout_message(&self, message: LayoutMessage, window_system: &dyn WindowSystem,
                                config: &GeneralConfig) -> WindowManager {
         self.modify_workspaces(|w| w.send_layout_message(message, window_system, config))
     }
 
     /// Close the currently focused window
-    pub fn close_window(&self, window_system: &WindowSystem) -> WindowManager {
+    pub fn close_window(&self, window_system: &dyn WindowSystem) -> WindowManager {
         self.workspaces.with_focused(|w| window_system.close_client(w));
         self.clone()
     }
 
     /// Kill the currently focused window
-    pub fn kill_window(&self, window_system: &WindowSystem) -> WindowManager {
+    pub fn kill_window(&self, window_system: &dyn WindowSystem) -> WindowManager {
         self.workspaces.with_focused(|w| window_system.kill_client(w));
         self.clone()
     }
@@ -303,7 +303,7 @@ impl WindowManager {
         Rectangle(sx + scale(sw, rx) as i32, sy + scale(sh, ry) as i32, scale(sw, rw), scale(sh, rh))
     }
 
-    fn tile_window(window_system: &WindowSystem, config: &GeneralConfig,
+    fn tile_window(window_system: &dyn WindowSystem, config: &GeneralConfig,
                    window: Window, Rectangle(x, y, w, h): Rectangle) {
         window_system.resize_window(window, w - 2 * config.border_width,
                                             h - 2 * config.border_width);
@@ -311,7 +311,7 @@ impl WindowManager {
         window_system.show_window(window);
     }
 
-    pub fn float_location(&self, window_system: &WindowSystem, window: Window) -> RationalRect {
+    pub fn float_location(&self, window_system: &dyn WindowSystem, window: Window) -> RationalRect {
         let Rectangle(sx, sy, sw, sh)   = self.workspaces.current.screen_detail;
         let Rectangle(rx, ry, rw, rh) = window_system.get_geometry(window);
 
@@ -321,17 +321,17 @@ impl WindowManager {
                       rh as f32 / sh as f32)
     }
 
-    pub fn float(&self, window_system: &WindowSystem, config: &GeneralConfig,
+    pub fn float(&self, window_system: &dyn WindowSystem, config: &GeneralConfig,
                  window: Window) -> WindowManager {
         let rect = self.float_location(window_system, window);
         let result = self.windows(window_system, config, &|w| w.float(window, rect));
         result
     }
 
-    pub fn mouse_drag(&self, window_system: &WindowSystem, f: Box<Fn(u32, u32, WindowManager, &WindowSystem) -> WindowManager>) -> WindowManager {
+    pub fn mouse_drag(&self, window_system: &dyn WindowSystem, f: Box<Fn(u32, u32, WindowManager, &dyn WindowSystem) -> WindowManager>) -> WindowManager {
         window_system.grab_pointer();
 
-        let motion = Rc::new(Box::new(move |x, y, window_manager, w: &WindowSystem| {
+        let motion = Rc::new(Box::new(move |x, y, window_manager, w: &dyn WindowSystem| {
             let z = f(x, y, window_manager, w);
             w.remove_motion_events();
             z.clone()
@@ -345,23 +345,23 @@ impl WindowManager {
         }
     }
 
-    pub fn mouse_move_window(&self, window_system: &WindowSystem, config: &GeneralConfig,
+    pub fn mouse_move_window(&self, window_system: &dyn WindowSystem, config: &GeneralConfig,
                              window: Window) -> WindowManager {
         let (ox, oy) = window_system.get_pointer(window);
         let Rectangle(x, y, _, _) = window_system.get_geometry(window);
 
-        self.mouse_drag(window_system, Box::new(move |ex: u32, ey: u32, m: WindowManager, w: &WindowSystem| {
+        self.mouse_drag(window_system, Box::new(move |ex: u32, ey: u32, m: WindowManager, w: &dyn WindowSystem| {
             w.move_window(window, x + (ex as i32 - ox as i32), y + (ey as i32 - oy as i32));
             m.modify_workspaces(|wsp| wsp.update_floating_rect(window, m.float_location(w, window)))
         })).float(window_system, config, window)
     }
 
-    pub fn mouse_resize_window(&self, window_system: &WindowSystem, config: &GeneralConfig,
+    pub fn mouse_resize_window(&self, window_system: &dyn WindowSystem, config: &GeneralConfig,
                              window: Window) -> WindowManager {
         let Rectangle(x, y, w, h) = window_system.get_geometry(window);
 
         window_system.warp_pointer(window, w, h);
-        self.mouse_drag(window_system, Box::new(move |ex: u32, ey: u32, m: WindowManager, w: &WindowSystem| {
+        self.mouse_drag(window_system, Box::new(move |ex: u32, ey: u32, m: WindowManager, w: &dyn WindowSystem| {
             let nx = cmp::max(0, ex as i32 - x) as u32;
             let ny = cmp::max(0, ey as i32 - y) as u32;
             w.resize_window(window, nx, ny);

--- a/core/src/wtftw.rs
+++ b/core/src/wtftw.rs
@@ -1,6 +1,6 @@
 #[deny(warnings)]
 #[macro_use]
-#[link]
+#[link(name="log")]
 extern crate log;
 #[macro_use]
 extern crate bitflags;

--- a/src/wtftw.rs
+++ b/src/wtftw.rs
@@ -50,7 +50,7 @@ fn main() {
     // Initialize window system. Use xlib here for now
     debug!("initialize window system");
     let xlib = XlibWindowSystem::new();
-    let window_system : Rc<WindowSystem> = Rc::new(xlib);
+    let window_system : Rc<dyn WindowSystem> = Rc::new(xlib);
     // Create the actual window manager
     debug!("create window manager");
     let mut window_manager = WindowManager::new(window_system.deref(), &config.general);


### PR DESCRIPTION
The standalone `#[link]` directive is no longer accepted by rust compilers. I have also removed a bunch of warnings that pop up on more recent compiler versions.